### PR TITLE
fix: update product_kind in manifest

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -3,7 +3,7 @@
         {
             "name": "terraform-ibm-modules-mock-module",
             "label": "Public Mock Module",
-            "product_kind": "software",
+            "product_kind": "module",
             "long_description": "A module to test catalog pipeline",
             "offering_docs_url": "https://github.com/terraform-ibm-modules/mock-module",
             "offering_icon_url": "https://globalcatalog.cloud.ibm.com/api/v1/1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc/artifacts/terraform.svg",


### PR DESCRIPTION
### Description

Just a small update to change the `product_kind` in the manifest from `software` to `module`

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Update `product_kind` to be `module` in manifest (`ibm_catalog.json`)

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
