### PR TITLE
feat:exposed visibility value for the provider in the DA

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -154,6 +154,23 @@
               "key": "region",
               "required": true,
               "type": "string"
+            },
+            {
+              "key": "provider_visibility",
+              "options": [
+                {
+                  "displayname": "private",
+                  "value": "private"
+                },
+                {
+                  "displayname": "public",
+                  "value": "public"
+                },
+                {
+                  "displayname": "public-and-private",
+                  "value": "public-and-private"
+                }
+              ]
             }
           ],
           "iam_permissions": [
@@ -215,6 +232,23 @@
               },
               "key": "region",
               "required": true
+            },
+            {
+              "key": "provider_visibility",
+              "options": [
+                {
+                  "displayname": "private",
+                  "value": "private"
+                },
+                {
+                  "displayname": "public",
+                  "value": "public"
+                },
+                {
+                  "displayname": "public-and-private",
+                  "value": "public-and-private"
+                }
+              ]
             }
           ],
           "iam_permissions": [
@@ -304,6 +338,23 @@
               },
               "key": "region",
               "required": true
+            },
+            {
+              "key": "provider_visibility",
+              "options": [
+                {
+                  "displayname": "private",
+                  "value": "private"
+                },
+                {
+                  "displayname": "public",
+                  "value": "public"
+                },
+                {
+                  "displayname": "public-and-private",
+                  "value": "public-and-private"
+                }
+              ]
             }
           ],
           "iam_permissions": [

--- a/solutions/mock-da-extension/provider.tf
+++ b/solutions/mock-da-extension/provider.tf
@@ -1,4 +1,5 @@
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
+  visibility       = var.provider_visibility
 }

--- a/solutions/mock-da-extension/variables.tf
+++ b/solutions/mock-da-extension/variables.tf
@@ -4,6 +4,16 @@ variable "ibmcloud_api_key" {
   sensitive   = true
 }
 
+variable "provider_visibility" {
+  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
+  type        = string
+  default     = "private"
+
+  validation {
+    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
+    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
+  }
+}
 variable "region" {
   type        = string
   description = "Region to provision all resources created by this example"

--- a/solutions/mock-da-quickstart/provider.tf
+++ b/solutions/mock-da-quickstart/provider.tf
@@ -1,4 +1,5 @@
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
+  visibility       = var.provider_visibility
 }

--- a/solutions/mock-da-quickstart/variables.tf
+++ b/solutions/mock-da-quickstart/variables.tf
@@ -4,6 +4,16 @@ variable "ibmcloud_api_key" {
   sensitive   = true
 }
 
+variable "provider_visibility" {
+  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
+  type        = string
+  default     = "private"
+
+  validation {
+    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
+    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
+  }
+}
 variable "region" {
   type        = string
   description = "Region to provision all resources created by this example"

--- a/solutions/mock-da/provider.tf
+++ b/solutions/mock-da/provider.tf
@@ -1,4 +1,5 @@
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
+  visibility       = var.provider_visibility
 }

--- a/solutions/mock-da/variables.tf
+++ b/solutions/mock-da/variables.tf
@@ -4,6 +4,16 @@ variable "ibmcloud_api_key" {
   sensitive   = true
 }
 
+variable "provider_visibility" {
+  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
+  type        = string
+  default     = "private"
+
+  validation {
+    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
+    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
+  }
+}
 variable "region" {
   type        = string
   description = "Region to provision all resources created by this example"


### PR DESCRIPTION
### Description

exposed [visibility](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs#visibility) value for the provider in the DA , with default value set to "private"

[Git issue](https://github.ibm.com/GoldenEye/issues/issues/11324)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

exposes visibility value for the provider in the DA

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
