### PR TITLE
fix: release_notes_url for community DA tile

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -1,6 +1,117 @@
 {
   "products": [
     {
+      "name": "terraform-ibm-mock-module",
+      "label": "Terraform IBM Mock Module",
+      "product_kind": "module",
+      "long_description": "A module to test catalog pipeline \n\nLeverage [Terraform IBM Modules](https://github.com/terraform-ibm-modules) to shape and scale your solutions. You can integrate Terraform IBM Modules (TIM) to extend functionality and design a solution tailored to your environment and operations needs. These modules offer reusable, customizable elements that follow IBM Cloud's recommended practices. You can access the [source code and documentation](https://github.com/terraform-ibm-modules/mock-module) and use it to extend your current architecture or create new solutions.",
+      "offering_docs_url": "https://github.com/terraform-ibm-modules/mock-module",
+      "offering_icon_url": "https://globalcatalog.cloud.ibm.com/api/v1/1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc/artifacts/terraform.svg",
+      "provider_name": "IBM",
+      "short_description": "Public mock module for testing purpose",
+      "tags": [
+        "dev_ops",
+        "ibm_created",
+        "terraform",
+        "module"
+      ],
+      "keywords": [
+        "mock",
+        "module",
+        "terraform"
+      ],
+      "features": [
+        {
+          "description": "module to test pipeline",
+          "title": "testing module"
+        },
+        {
+          "title": "Composable and Extensible Architecture",
+          "description": "This architecture illustrates how Terraform IBM Modules(TIM) can be integrated to deliver a complete solution on IBM Cloud. Each module is a reusable, and validated component for security, compliance, and operational IBM best practices. You can deploy this architecture as-is or configure it as code by leveraging the underlying modules to fit your specific requirements. Explore the [source code and documentation](https://github.com/terraform-ibm-modules/mock-module) to adapt, extend, or create entirely new solutions using these building blocks."
+        }
+      ],
+      "flavors": [
+        {
+          "label": "Basic",
+          "name": "basic",
+          "install_type": "fullstack",
+          "working_directory": "examples/basic",
+          "short_description": "mock module - basic example",
+          "architecture": {
+            "features": [
+              {
+                "title": "Mock feature 1",
+                "description": "Mock feature 1 description"
+              },
+              {
+                "title": "Mock feature 2",
+                "description": "Mock feature 2 description"
+              }
+            ],
+            "diagrams": [
+              {
+                "diagram": {
+                  "caption": "Mock Module",
+                  "url": "https://www.svgrepo.com/show/532064/rainbow.svg",
+                  "type": "image/svg+xml"
+                },
+                "description": "This is a mock module diagram"
+              }
+            ]
+          },
+          "iam_permissions": [
+            {
+              "role_crns": [
+                "crn:v1:bluemix:public:iam::::role:Administrator"
+              ],
+              "service_name": "is.vpc"
+            }
+          ],
+          "terraform_version": "1.12.2",
+          "ignore_readme": true
+        },
+        {
+          "label": "Complete",
+          "name": "complete",
+          "install_type": "fullstack",
+          "working_directory": "examples/complete",
+          "short_description": "mock module - complete example",
+          "architecture": {
+            "features": [
+              {
+                "title": "Mock feature 1",
+                "description": "Mock feature 1 description"
+              },
+              {
+                "title": "Mock feature 2",
+                "description": "Mock feature 2 description"
+              }
+            ],
+            "diagrams": [
+              {
+                "diagram": {
+                  "caption": "Mock Module",
+                  "url": "https://www.svgrepo.com/show/532064/rainbow.svg",
+                  "type": "image/svg+xml"
+                },
+                "description": "This is a mock module diagram"
+              }
+            ]
+          },
+          "iam_permissions": [
+            {
+              "role_crns": [
+                "crn:v1:bluemix:public:iam::::role:Administrator"
+              ],
+              "service_name": "is.vpc"
+            }
+          ],
+          "terraform_version": "1.12.2",
+          "ignore_readme": true
+        }
+      ]
+    },
+    {
       "name": "deploy-arch-ibm-mock-module",
       "label": "Mock DA",
       "product_kind": "solution",


### PR DESCRIPTION

### Description

This PR fixes the `release_notes_url` in the `ibm_catalog.json` file for the community DA tile.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Fix `release_notes_url` in `ibm_catalog.json`.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
